### PR TITLE
Don't propagate touch to items behind a header (update StickyRecyclerHeadersTouchListener)

### DIFF
--- a/library/src/main/java/com/timehop/stickyheadersrecyclerview/StickyRecyclerHeadersTouchListener.java
+++ b/library/src/main/java/com/timehop/stickyheadersrecyclerview/StickyRecyclerHeadersTouchListener.java
@@ -40,7 +40,17 @@ public class StickyRecyclerHeadersTouchListener implements RecyclerView.OnItemTo
 
   @Override
   public boolean onInterceptTouchEvent(RecyclerView view, MotionEvent e) {
-    return mOnHeaderClickListener != null && mTapDetector.onTouchEvent(e);
+        if (this.mOnHeaderClickListener != null) {
+            boolean tapDetectorResponse = this.mTapDetector.onTouchEvent(e);
+            if (tapDetectorResponse) {
+                return true;
+            }
+            if (e.getAction() == MotionEvent.ACTION_DOWN) {
+                int position = mDecor.findHeaderPositionUnder((int)e.getX(), (int)e.getY());
+                return position != -1;
+            }
+        }
+        return false;
   }
 
   @Override


### PR DESCRIPTION
When a sticky header is touched, a regular item behind it may receive the ACTION_DOWN event, and display "pressed" state.  This commit fixes such undesired behavior by returning _true_ for `onInterceptTouchEvent()` if it was DOWN inside the borders of a sticky header.
